### PR TITLE
fix: Subdomain field is replaced with the subdomain name

### DIFF
--- a/main.go
+++ b/main.go
@@ -80,8 +80,8 @@ func main() {
 
 				for _, subdomain := range subdomains {
 					logFields := convertToLogrusFields(map[string]string{
-						"domain":  domain,
-						subdomain: subdomain,
+						"domain":    domain,
+						"subdomain": subdomain,
 					})
 					subdomainLogger := log.WithFields(logFields)
 


### PR DESCRIPTION
Instead of login something like 

```json
{ "subdomain": "mysubdomain", "domain":"example.com", "....": "...."}
```

The application was login

```json
{ "mysubdomain": "mysubdomain", "domain":"example.com", "....": "...."}
```